### PR TITLE
Fixes bug of nav bar not showing on landscape ipad

### DIFF
--- a/modules/hide/index.css
+++ b/modules/hide/index.css
@@ -28,6 +28,5 @@
 
 @custom-media --breakpoint-xs (max-width: 40em);
 @custom-media --breakpoint-sm-md (min-width: 40em) and (max-width: 52em);
-@custom-media --breakpoint-md-lg (min-width: 52em) and (max-width: 64em);
-@custom-media --breakpoint-lg (min-width: 64.001em);
-
+@custom-media --breakpoint-md-lg (min-width: 52em) and (max-width: 64.0619em);
+@custom-media --breakpoint-lg (min-width: 64.0619em);


### PR DESCRIPTION
I changed breakpoint bounds for md-lg and lg screens. Specifically md-lg 
upper bound and lg lower bound both to 64.0619em 

[#162988983]